### PR TITLE
fix: prevent crash after removing laravel-project-initializator

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -214,11 +214,11 @@ class InitCommand extends Command implements Isolatable
 
         $this->setupComposerHooks();
 
+        $this->setAutoDocContactEmail($this->codeOwnerEmail);
+
         foreach ($this->shellCommands as $shellCommand) {
             shell_exec("{$shellCommand} --ansi");
         }
-
-        $this->setAutoDocContactEmail($this->codeOwnerEmail);
 
         Artisan::call('migrate');
     }


### PR DESCRIPTION
Refs: https://github.com/RonasIT/laravel-project-initializator/issues/39#event-19973612254